### PR TITLE
Disables picture in picture and enhances hover on posts

### DIFF
--- a/src/templates/HomeTemplate/index.tsx
+++ b/src/templates/HomeTemplate/index.tsx
@@ -21,7 +21,7 @@ export const HomeTemplate = (props: HomeTemplateProps) => {
 
   return (
     <>
-      <S.VideoBanner muted autoPlay loop ref={videoRef}>
+      <S.VideoBanner muted disablePictureInPicture autoPlay loop ref={videoRef}>
         <source src="/videos/rocket.mp4" type="video/mp4" />
       </S.VideoBanner>
 

--- a/src/templates/PostsTemplate/PostsList/styles.ts
+++ b/src/templates/PostsTemplate/PostsList/styles.ts
@@ -32,6 +32,12 @@ export const PostContainer = styled.div``
 export const Post = styled(Link)`
   display: flex;
   flex-direction: column;
+
+  &:hover {
+    img:only-child {
+      transform: scale(1.1);
+    }
+  }
 `
 
 export const PostThumbnailWrapper = styled.figure`
@@ -40,12 +46,6 @@ export const PostThumbnailWrapper = styled.figure`
   position: relative;
 
   border: 1px solid ${({ theme }) => theme.colors.shape};
-
-  &:hover {
-    img {
-      transform: scale(1.1);
-    }
-  }
 `
 
 export const PostThumbnail = styled(Image)`

--- a/src/templates/PostsTemplate/index.tsx
+++ b/src/templates/PostsTemplate/index.tsx
@@ -18,7 +18,7 @@ export const PostsTemplate = (props: PostsTemplateProps) => {
   return (
     <>
       <S.VideoOverlay />
-      <S.VideoBanner muted autoPlay loop ref={videoRef}>
+      <S.VideoBanner disablePictureInPicture muted autoPlay loop ref={videoRef}>
         <source src="/videos/galaxy.mp4" type="video/mp4" />
       </S.VideoBanner>
 


### PR DESCRIPTION
On some Browsers, when a video has support to picture and picture, it shows an icon to enable it:

![Screenshot_5](https://user-images.githubusercontent.com/42651514/196065277-8f21b8d2-78ba-43b2-8812-0bc51538b4da.png)
![image](https://user-images.githubusercontent.com/42651514/196065312-5ec0c7d9-23e3-4d9e-a7c1-5b5f133ac201.png)
But since it doesn't increase the user experience at all, and the video acts as a background, I disabled it.

Also changed the hover on posts. Instead of applying the image transform scale only when hovering on the post image itself, it now applies when hovering on any part the entire post., which makes more sense and adds a sense of "I can click here". 